### PR TITLE
Multi-Repository Support for Git MCP Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,14 +58,12 @@ The Git MCP Server uses a command-line structure with subcommands:
 ```
 git-mcp-go
 ├── serve [flags] [repository-paths...]
-│   ├── --repository, -r <path>                   # Single repository (backward compatibility)
-│   ├── --repositories <path>                     # Multiple repositories (can be specified multiple times)
+│   ├── --repository, -r <paths>                  # Repository paths (multiple ways to specify)
 │   ├── --mode <shell|go-git>
 │   ├── --write-access
 │   └── --verbose, -v
 └── setup [flags] [repository-paths...]
-    ├── --repository, -r <path>                   # Single repository (backward compatibility)
-    ├── --repositories <path>                     # Multiple repositories (can be specified multiple times)
+    ├── --repository, -r <paths>                  # Repository paths (multiple ways to specify)
     ├── --mode <shell|go-git>
     ├── --write-access
     ├── --auto-approve <tool-list|allow-read-only|allow-local-only>
@@ -76,9 +74,11 @@ git-mcp-go
 
 The Git MCP Server can now monitor and operate on multiple repositories simultaneously. You can specify repositories in several ways:
 
-1. Using the `-r/--repository` flag (single repository, for backward compatibility)
-2. Using the `--repositories` flag (can be specified multiple times)
-3. Providing repository paths as arguments after the command
+1. Using the `-r/--repository` flag:
+   - With comma-separated paths: `-r=/path/to/repo1,/path/to/repo2`
+   - With multiple flag instances: `-r=/path/to/repo1 -r=/path/to/repo2`
+2. As positional arguments: `serve /path/to/repo1 /path/to/repo2`
+3. A combination of both approaches
 
 When using multiple repositories, the server will default to the first repository for operations where a specific repository is not specified.
 
@@ -87,26 +87,29 @@ When using multiple repositories, the server will default to the first repositor
 The `serve` command starts the Git MCP server:
 
 ```bash
-# Run with a single repository (backward compatibility)
+# Run with a single repository
 ./git-mcp-go serve -r /path/to/git/repository
 
-# Run with multiple repositories using --repositories flag
-./git-mcp-go serve --repositories=/path/to/repo1 --repositories=/path/to/repo2
+# Run with multiple repositories using comma-separated values
+./git-mcp-go serve -r=/path/to/repo1,/path/to/repo2,/path/to/repo3
 
-# Run with multiple repositories as arguments
+# Run with multiple repository flags
+./git-mcp-go serve -r=/path/to/repo1 -r=/path/to/repo2
+
+# Run with repositories as arguments
 ./git-mcp-go serve /path/to/repo1 /path/to/repo2 /path/to/repo3
 
-# Combining all methods
-./git-mcp-go serve -r /path/to/main-repo --repositories=/path/to/repo2 /path/to/repo3
+# Combining flag and arguments
+./git-mcp-go serve -r=/path/to/repo1 /path/to/repo2 /path/to/repo3
 
 # Run with verbose logging
-./git-mcp-go serve -v --repositories=/path/to/repo1 --repositories=/path/to/repo2
+./git-mcp-go serve -v -r=/path/to/repo1,/path/to/repo2
 
 # Run with go-git implementation
-./git-mcp-go serve --mode go-git --repositories=/path/to/repo1 --repositories=/path/to/repo2
+./git-mcp-go serve --mode go-git -r=/path/to/repo1,/path/to/repo2
 
 # Enable write access for remote operations
-./git-mcp-go serve --repositories=/path/to/repo1 --repositories=/path/to/repo2 --write-access
+./git-mcp-go serve -r=/path/to/repo1,/path/to/repo2 --write-access
 ```
 
 The `--mode` flag allows you to choose between two different implementations:
@@ -121,26 +124,29 @@ The `--write-access` flag enables operations that modify remote state (currently
 The `setup` command sets up the Git MCP server for use with an AI assistant. It copies itself to `~/mcp-servers/git-mcp-go` and modifies the tools config (cline: `cline_mcp_settings.json`) to use that binary.
 
 ```bash
-# Set up for Cline with a single repository (backward compatibility)
+# Set up for Cline with a single repository
 ./git-mcp-go setup -r /path/to/git/repository
 
-# Set up with multiple repositories using --repositories flag
-./git-mcp-go setup --repositories=/path/to/repo1 --repositories=/path/to/repo2
+# Set up with multiple repositories using comma-separated values
+./git-mcp-go setup -r=/path/to/repo1,/path/to/repo2,/path/to/repo3
 
-# Set up with multiple repositories as arguments
+# Set up with multiple repository flags
+./git-mcp-go setup -r=/path/to/repo1 -r=/path/to/repo2
+
+# Set up with repositories as arguments
 ./git-mcp-go setup /path/to/repo1 /path/to/repo2 /path/to/repo3
 
 # Set up with write access enabled
-./git-mcp-go setup --repositories=/path/to/repo1 --repositories=/path/to/repo2 --write-access
+./git-mcp-go setup -r=/path/to/repo1,/path/to/repo2 --write-access
 
 # Set up with auto-approval for read-only tools
-./git-mcp-go setup --repositories=/path/to/repo1 --repositories=/path/to/repo2 --auto-approve=allow-read-only
+./git-mcp-go setup -r=/path/to/repo1,/path/to/repo2 --auto-approve=allow-read-only
 
 # Set up with specific tools auto-approved
-./git-mcp-go setup --repositories=/path/to/repo1 --repositories=/path/to/repo2 --auto-approve=git_status,git_log
+./git-mcp-go setup -r=/path/to/repo1,/path/to/repo2 --auto-approve=git_status,git_log
 
 # Set up with write access and auto-approval for read-only tools
-./git-mcp-go setup --repositories=/path/to/repo1 --repositories=/path/to/repo2 --write-access --auto-approve=allow-read-only
+./git-mcp-go setup -r=/path/to/repo1,/path/to/repo2 --write-access --auto-approve=allow-read-only
 ```
 
 The `--auto-approve` flag allows you to specify which tools should be auto-approved (not require explicit user approval):
@@ -194,7 +200,7 @@ chmod +x ./git-mcp-go
 ./git-mcp-go setup -r /path/to/git/repository --tool=cline --auto-approve=allow-local-only
 
 # Setup the mcp server with multiple repositories
-./git-mcp-go setup --repositories=/path/to/repo1 --repositories=/path/to/repo2 --tool=cline --auto-approve=allow-local-only
+./git-mcp-go setup -r=/path/to/repo1,/path/to/repo2 --tool=cline --auto-approve=allow-local-only
 
 rm -f ./git-mcp-go
 ```
@@ -211,7 +217,7 @@ Alternatively, you can manually add this to your `claude_desktop_config.json`:
 "mcpServers": {
   "git": {
     "command": "/path/to/git-mcp-go",
-    "args": ["serve", "--repositories=/path/to/repo1", "--repositories=/path/to/repo2", "--mode", "shell"]
+    "args": ["serve", "-r=/path/to/repo1,/path/to/repo2", "--mode", "shell"]
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -87,23 +87,8 @@ When using multiple repositories, the server will default to the first repositor
 The `serve` command starts the Git MCP server:
 
 ```bash
-# Run with a single repository
-./git-mcp-go serve -r /path/to/git/repository
-
-# Run with multiple repositories using comma-separated values
-./git-mcp-go serve -r=/path/to/repo1,/path/to/repo2,/path/to/repo3
-
-# Run with multiple repository flags
-./git-mcp-go serve -r=/path/to/repo1 -r=/path/to/repo2
-
-# Run with repositories as arguments
-./git-mcp-go serve /path/to/repo1 /path/to/repo2 /path/to/repo3
-
-# Combining flag and arguments
-./git-mcp-go serve -r=/path/to/repo1 /path/to/repo2 /path/to/repo3
-
 # Run with verbose logging
-./git-mcp-go serve -v -r=/path/to/repo1,/path/to/repo2
+./git-mcp-go serve -v /path/to/repo1 /path/to/repo2 /path/to/repo3
 
 # Run with go-git implementation
 ./git-mcp-go serve --mode go-git -r=/path/to/repo1,/path/to/repo2
@@ -126,12 +111,6 @@ The `setup` command sets up the Git MCP server for use with an AI assistant. It 
 ```bash
 # Set up for Cline with a single repository
 ./git-mcp-go setup -r /path/to/git/repository
-
-# Set up with multiple repositories using comma-separated values
-./git-mcp-go setup -r=/path/to/repo1,/path/to/repo2,/path/to/repo3
-
-# Set up with multiple repository flags
-./git-mcp-go setup -r=/path/to/repo1 -r=/path/to/repo2
 
 # Set up with repositories as arguments
 ./git-mcp-go setup /path/to/repo1 /path/to/repo2 /path/to/repo3
@@ -222,13 +201,11 @@ Alternatively, you can manually add this to your `claude_desktop_config.json`:
 }
 ```
 
-For backward compatibility, the following still works for a single repository:
-
 ```json
 "mcpServers": {
   "git": {
     "command": "/path/to/git-mcp-go",
-    "args": ["serve", "-r", "/path/to/git/repository", "--mode", "shell"]
+    "args": ["serve", "-r", "/path/to/git/repository"]
   }
 }
 ```

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -13,7 +13,6 @@ import (
 )
 
 var (
-	repoPath    string
 	repoPaths   []string
 	verbose     bool
 	mode        string
@@ -22,13 +21,13 @@ var (
 
 // serveCmd represents the serve command
 var serveCmd = &cobra.Command{
-	Use:   "serve",
+	Use:   "serve [repository-paths...]",
 	Short: "Start the Git MCP server",
 	Long: `Start the Git MCP server.
 
 This command starts the Git MCP server, which provides tools for interacting with Git repositories through the MCP protocol.
 
-You can specify multiple repositories using the --repositories flag or by passing paths as arguments.`,
+You can specify multiple repositories using the -r/--repository flag (can be repeated or comma-separated) or by passing paths as arguments.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Create the appropriate GitOperations implementation
 		var gitOps gitops.GitOperations
@@ -53,19 +52,14 @@ You can specify multiple repositories using the --repositories flag or by passin
 		// Collect all repository paths
 		allRepoPaths := make([]string, 0)
 		
-		// Add the single repository if specified
-		if repoPath != "" {
-			allRepoPaths = append(allRepoPaths, repoPath)
-		}
-		
-		// Add repositories from the repositories flag
+		// Add repositories from the -r/--repository flag
 		allRepoPaths = append(allRepoPaths, repoPaths...)
 		
 		// Add repositories from arguments
 		allRepoPaths = append(allRepoPaths, args...)
 		
 		if len(allRepoPaths) == 0 {
-			fmt.Fprintf(os.Stderr, "Error: No repositories specified. Use --repository, --repositories, or provide paths as arguments.\n")
+			fmt.Fprintf(os.Stderr, "Error: No repositories specified. Use --repository or provide paths as arguments.\n")
 			os.Exit(1)
 		}
 
@@ -97,8 +91,8 @@ func init() {
 	rootCmd.AddCommand(serveCmd)
 
 	// Add flags to the server command
-	serveCmd.Flags().StringVarP(&repoPath, "repository", "r", "", "Git repository path (single repository, for backward compatibility)")
-	serveCmd.Flags().StringArrayVar(&repoPaths, "repositories", []string{}, "Git repository paths (can be specified multiple times)")
+	serveCmd.Flags().StringSliceVarP(&repoPaths, "repository", "r", []string{}, 
+		"Git repository paths (can be specified multiple times, comma-separated, or as positional arguments)")
 	serveCmd.Flags().StringVar(&mode, "mode", "shell", "Git operation mode: 'shell' or 'go-git'")
 	serveCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose logging")
 	serveCmd.Flags().BoolVar(&writeAccess, "write-access", false, "Enable write access for remote operations (push)")

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -14,6 +14,7 @@ import (
 
 var (
 	repoPath    string
+	repoPaths   []string
 	verbose     bool
 	mode        string
 	writeAccess bool
@@ -25,7 +26,9 @@ var serveCmd = &cobra.Command{
 	Short: "Start the Git MCP server",
 	Long: `Start the Git MCP server.
 
-This command starts the Git MCP server, which provides tools for interacting with Git repositories through the MCP protocol.`,
+This command starts the Git MCP server, which provides tools for interacting with Git repositories through the MCP protocol.
+
+You can specify multiple repositories using the --repositories flag or by passing paths as arguments.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Create the appropriate GitOperations implementation
 		var gitOps gitops.GitOperations
@@ -47,8 +50,34 @@ This command starts the Git MCP server, which provides tools for interacting wit
 			gitOps = shell.NewShellGitOperations()
 		}
 
+		// Collect all repository paths
+		allRepoPaths := make([]string, 0)
+		
+		// Add the single repository if specified
+		if repoPath != "" {
+			allRepoPaths = append(allRepoPaths, repoPath)
+		}
+		
+		// Add repositories from the repositories flag
+		allRepoPaths = append(allRepoPaths, repoPaths...)
+		
+		// Add repositories from arguments
+		allRepoPaths = append(allRepoPaths, args...)
+		
+		if len(allRepoPaths) == 0 {
+			fmt.Fprintf(os.Stderr, "Error: No repositories specified. Use --repository, --repositories, or provide paths as arguments.\n")
+			os.Exit(1)
+		}
+
+		if verbose {
+			fmt.Printf("Monitoring %d repositories\n", len(allRepoPaths))
+			for i, path := range allRepoPaths {
+				fmt.Printf("  %d. %s\n", i+1, path)
+			}
+		}
+
 		// Create and configure the Git MCP server
-		gitServer := pkg.NewGitServer(repoPath, gitOps, writeAccess)
+		gitServer := pkg.NewGitServer(allRepoPaths, gitOps, writeAccess)
 
 		// Register all Git tools
 		gitServer.RegisterTools()
@@ -68,7 +97,8 @@ func init() {
 	rootCmd.AddCommand(serveCmd)
 
 	// Add flags to the server command
-	serveCmd.Flags().StringVarP(&repoPath, "repository", "r", "", "Git repository path")
+	serveCmd.Flags().StringVarP(&repoPath, "repository", "r", "", "Git repository path (single repository, for backward compatibility)")
+	serveCmd.Flags().StringArrayVar(&repoPaths, "repositories", []string{}, "Git repository paths (can be specified multiple times)")
 	serveCmd.Flags().StringVar(&mode, "mode", "shell", "Git operation mode: 'shell' or 'go-git'")
 	serveCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose logging")
 	serveCmd.Flags().BoolVar(&writeAccess, "write-access", false, "Enable write access for remote operations (push)")

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -76,6 +76,11 @@ You can specify one or more git repositories using:
 		// Add repositories from arguments
 		allRepoPaths = append(allRepoPaths, args...)
 
+		if len(allRepoPaths) == 0 {
+			fmt.Fprintf(os.Stderr, "Error: No repositories specified. Use -r/--repository flag or provide paths as arguments.\n")
+			os.Exit(1)
+		}
+
 		// Process each tool
 		tools := strings.Split(tool, ",")
 		hasErrors := false
@@ -195,10 +200,17 @@ func setupTool(toolName string, binaryPath string, repoPaths []string, writeAcce
 
 	serverArgs := []string{"serve"}
 	
-	// Add repositories to args
-	for _, repoPath := range repoPaths {
-		if repoPath != "" {
-			serverArgs = append(serverArgs, "-r="+repoPath)
+	// Add repositories to args based on the number of repositories
+	// For backward compatibility with tests, use --repository format for single repository
+	if len(repoPaths) == 1 {
+		// This format is needed for test compatibility
+		serverArgs = append(serverArgs, "--repository="+repoPaths[0])
+	} else {
+		// For multiple repositories, use the -r flag with each path
+		for _, repoPath := range repoPaths {
+			if repoPath != "" {
+				serverArgs = append(serverArgs, "-r="+repoPath)
+			}
 		}
 	}
 	

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -23,8 +23,8 @@ func init() {
 	rootCmd.AddCommand(setupCmd)
 
 	// Add flags to the setup command
-	setupCmd.Flags().StringVarP(&repoPath, "repository", "r", "", "Git repository path (single repository, for backward compatibility)")
-	setupCmd.Flags().StringArrayVar(&repoPaths, "repositories", []string{}, "Git repository paths (can be specified multiple times)")
+	setupCmd.Flags().StringSliceVarP(&repoPaths, "repository", "r", []string{}, 
+		"Git repository paths (can be specified multiple times, comma-separated, or as positional arguments)")
 	setupCmd.Flags().StringVar(&mode, "mode", "shell", "Git operation mode: 'shell' or 'go-git'")
 	setupCmd.Flags().BoolVar(&writeAccess, "write-access", false, "Enable write access for remote operations (push)")
 	setupCmd.Flags().StringVar(&tool, "tool", "cline", "The AI assistant tool(s) to set up for (comma-separated, e.g., cline,roo-code)")
@@ -40,8 +40,7 @@ var setupCmd = &cobra.Command{
 This command sets up the Git MCP server for use with an AI assistant by installing the binary and configuring the AI assistant to use it.
 
 You can specify one or more git repositories using:
-- The --repository flag (single repository, for backward compatibility)
-- The --repositories flag (can be specified multiple times)
+- The -r/--repository flag (can be specified multiple times or comma-separated)
 - Additional arguments (repository paths)`,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Create the MCP servers directory if it doesn't exist
@@ -71,12 +70,7 @@ You can specify one or more git repositories using:
 		// Collect all repository paths
 		allRepoPaths := make([]string, 0)
 		
-		// Add the single repository if specified
-		if repoPath != "" {
-			allRepoPaths = append(allRepoPaths, repoPath)
-		}
-		
-		// Add repositories from the repositories flag
+		// Add repositories from the -r/--repository flag
 		allRepoPaths = append(allRepoPaths, repoPaths...)
 		
 		// Add repositories from arguments
@@ -204,7 +198,7 @@ func setupTool(toolName string, binaryPath string, repoPaths []string, writeAcce
 	// Add repositories to args
 	for _, repoPath := range repoPaths {
 		if repoPath != "" {
-			serverArgs = append(serverArgs, "--repositories="+repoPath)
+			serverArgs = append(serverArgs, "-r="+repoPath)
 		}
 	}
 	

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -23,7 +23,8 @@ func init() {
 	rootCmd.AddCommand(setupCmd)
 
 	// Add flags to the setup command
-	setupCmd.Flags().StringVarP(&repoPath, "repository", "r", "", "Git repository path")
+	setupCmd.Flags().StringVarP(&repoPath, "repository", "r", "", "Git repository path (single repository, for backward compatibility)")
+	setupCmd.Flags().StringArrayVar(&repoPaths, "repositories", []string{}, "Git repository paths (can be specified multiple times)")
 	setupCmd.Flags().StringVar(&mode, "mode", "shell", "Git operation mode: 'shell' or 'go-git'")
 	setupCmd.Flags().BoolVar(&writeAccess, "write-access", false, "Enable write access for remote operations (push)")
 	setupCmd.Flags().StringVar(&tool, "tool", "cline", "The AI assistant tool(s) to set up for (comma-separated, e.g., cline,roo-code)")
@@ -32,11 +33,16 @@ func init() {
 
 // setupCmd represents the setup command
 var setupCmd = &cobra.Command{
-	Use:   "setup",
+	Use:   "setup [repository-paths...]",
 	Short: "Set up the Git MCP server for use with an AI assistant",
 	Long: `Set up the Git MCP server for use with an AI assistant.
 
-This command sets up the Git MCP server for use with an AI assistant by installing the binary and configuring the AI assistant to use it.`,
+This command sets up the Git MCP server for use with an AI assistant by installing the binary and configuring the AI assistant to use it.
+
+You can specify one or more git repositories using:
+- The --repository flag (single repository, for backward compatibility)
+- The --repositories flag (can be specified multiple times)
+- Additional arguments (repository paths)`,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Create the MCP servers directory if it doesn't exist
 		homeDir, err := os.UserHomeDir()
@@ -62,6 +68,20 @@ This command sets up the Git MCP server for use with an AI assistant by installi
 			}
 		}
 
+		// Collect all repository paths
+		allRepoPaths := make([]string, 0)
+		
+		// Add the single repository if specified
+		if repoPath != "" {
+			allRepoPaths = append(allRepoPaths, repoPath)
+		}
+		
+		// Add repositories from the repositories flag
+		allRepoPaths = append(allRepoPaths, repoPaths...)
+		
+		// Add repositories from arguments
+		allRepoPaths = append(allRepoPaths, args...)
+
 		// Process each tool
 		tools := strings.Split(tool, ",")
 		hasErrors := false
@@ -78,9 +98,9 @@ This command sets up the Git MCP server for use with an AI assistant by installi
 			var err error
 			switch strings.ToLower(t) {
 			case "cline":
-				err = setupCline(binaryPath, repoPath, writeAccess, autoApprove)
+				err = setupCline(binaryPath, allRepoPaths, writeAccess, autoApprove)
 			case "roo-code":
-				err = setupRooCode(binaryPath, repoPath, writeAccess, autoApprove)
+				err = setupRooCode(binaryPath, allRepoPaths, writeAccess, autoApprove)
 			default:
 				fmt.Printf("Unsupported tool: %s\n", t)
 				fmt.Println("Currently supported tools: cline, roo-code")
@@ -173,16 +193,21 @@ func copySelfToBinaryPath(binaryPath string) error {
 }
 
 // setupTool sets up the git-mcp-go server for a specific tool
-func setupTool(toolName string, binaryPath string, repoPath string, writeAccess bool, autoApprove string, configDir string) error {
+func setupTool(toolName string, binaryPath string, repoPaths []string, writeAccess bool, autoApprove string, configDir string) error {
 	// Create the config directory if it doesn't exist
 	if err := os.MkdirAll(configDir, 0755); err != nil {
 		return fmt.Errorf("failed to create config directory: %w", err)
 	}
 
 	serverArgs := []string{"serve"}
-	if repoPath != "" {
-		serverArgs = append(serverArgs, "--repository="+repoPath)
+	
+	// Add repositories to args
+	for _, repoPath := range repoPaths {
+		if repoPath != "" {
+			serverArgs = append(serverArgs, "--repositories="+repoPath)
+		}
 	}
+	
 	if writeAccess {
 		serverArgs = append(serverArgs, "--write-access=true")
 	}
@@ -264,7 +289,7 @@ func setupTool(toolName string, binaryPath string, repoPath string, writeAccess 
 }
 
 // setupCline sets up the git-mcp-go server for Cline
-func setupCline(binaryPath string, repoPath string, writeAccess bool, autoApprove string) error {
+func setupCline(binaryPath string, repoPaths []string, writeAccess bool, autoApprove string) error {
 	// Determine the Cline config directory
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
@@ -283,11 +308,11 @@ func setupCline(binaryPath string, repoPath string, writeAccess bool, autoApprov
 		return fmt.Errorf("unsupported OS: %s", runtime.GOOS)
 	}
 
-	return setupTool("Cline", binaryPath, repoPath, writeAccess, autoApprove, configDir)
+	return setupTool("Cline", binaryPath, repoPaths, writeAccess, autoApprove, configDir)
 }
 
 // setupRooCode sets up the git-mcp-go server for Roo Code
-func setupRooCode(binaryPath string, repoPath string, writeAccess bool, autoApprove string) error {
+func setupRooCode(binaryPath string, repoPaths []string, writeAccess bool, autoApprove string) error {
 	// Determine the Roo Code config directory
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
@@ -306,5 +331,5 @@ func setupRooCode(binaryPath string, repoPath string, writeAccess bool, autoAppr
 		return fmt.Errorf("unsupported OS: %s", runtime.GOOS)
 	}
 
-	return setupTool("Roo Code", binaryPath, repoPath, writeAccess, autoApprove, configDir)
+	return setupTool("Roo Code", binaryPath, repoPaths, writeAccess, autoApprove, configDir)
 }

--- a/pkg/multi_repo_test.go
+++ b/pkg/multi_repo_test.go
@@ -1,0 +1,144 @@
+package pkg
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/geropl/git-mcp-go/pkg/gitops/shell"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMultiRepositorySupport(t *testing.T) {
+	// Create multiple test repositories
+	repo1Dir := t.TempDir()
+	repo2Dir := t.TempDir()
+	repo3Dir := t.TempDir()
+
+	// Initialize the repositories
+	gitOps := shell.NewShellGitOperations()
+	
+	// Initialize the repos
+	_, err := gitOps.InitRepo(repo1Dir)
+	require.NoError(t, err, "Failed to initialize repo1")
+	
+	_, err = gitOps.InitRepo(repo2Dir)
+	require.NoError(t, err, "Failed to initialize repo2")
+	
+	_, err = gitOps.InitRepo(repo3Dir)
+	require.NoError(t, err, "Failed to initialize repo3")
+
+	t.Run("TestGitListRepositories", func(t *testing.T) {
+		// Create a server with multiple repositories
+		repoPaths := []string{repo1Dir, repo2Dir, repo3Dir}
+		server := NewGitServer(repoPaths, gitOps, false)
+		server.RegisterTools()
+
+		// Call the git_list_repositories tool
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "git_list_repositories"
+		request.Params.Arguments = map[string]interface{}{}
+
+		result, err := server.gitListRepositoriesHandler(context.Background(), request)
+		require.NoError(t, err, "List repositories handler should not return error")
+		require.NotNil(t, result, "Result should not be nil")
+
+		// Verify the result
+		if len(result.Content) > 0 {
+			text := ""
+			if textContent, ok := mcp.AsTextContent(result.Content[0]); ok {
+				text = textContent.Text
+			}
+
+			// Check that the output contains information about all repositories
+			assert.Contains(t, text, "Available repositories (3)", "Should show 3 repositories")
+			for _, repoPath := range repoPaths {
+				assert.Contains(t, text, repoPath, "Output should contain the repository path")
+			}
+		} else {
+			t.Fatalf("No content in result")
+		}
+	})
+
+	t.Run("TestRepositorySelection", func(t *testing.T) {
+		// Create a server with multiple repositories
+		repoPaths := []string{repo1Dir, repo2Dir, repo3Dir}
+		server := NewGitServer(repoPaths, gitOps, false)
+		
+		// Test default repository selection (first repository)
+		selectedPath, err := server.getRepoPathForOperation("")
+		require.NoError(t, err, "Default repository selection should not error")
+		assert.Equal(t, repo1Dir, selectedPath, "Default should be the first repository")
+
+		// Test specific repository selection
+		selectedPath, err = server.getRepoPathForOperation(repo2Dir)
+		require.NoError(t, err, "Specific repository selection should not error")
+		assert.Equal(t, repo2Dir, selectedPath, "Should select the specified repository")
+
+		// Test invalid repository selection
+		_, err = server.getRepoPathForOperation("/invalid/path")
+		require.Error(t, err, "Invalid repository selection should error")
+		assert.Contains(t, err.Error(), "access denied", "Error should mention access denied")
+	})
+
+	t.Run("TestOperationsAcrossMultipleRepositories", func(t *testing.T) {
+		// Create a server with multiple repositories
+		repoPaths := []string{repo1Dir, repo2Dir, repo3Dir}
+		server := NewGitServer(repoPaths, gitOps, false)
+		server.RegisterTools()
+
+		// Test git_status on different repositories
+		// First repository (default)
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "git_status"
+		request.Params.Arguments = map[string]interface{}{}
+
+		result, err := server.gitStatusHandler(context.Background(), request)
+		require.NoError(t, err, "Status on default repository should not error")
+		if len(result.Content) > 0 {
+			text := ""
+			if textContent, ok := mcp.AsTextContent(result.Content[0]); ok {
+				text = textContent.Text
+			}
+			assert.Contains(t, text, repo1Dir, "Output should reference the first repository")
+		}
+
+		// Second repository (explicit)
+		request = mcp.CallToolRequest{}
+		request.Params.Name = "git_status"
+		request.Params.Arguments = map[string]interface{}{
+			"repo_path": repo2Dir,
+		}
+
+		result, err = server.gitStatusHandler(context.Background(), request)
+		require.NoError(t, err, "Status on second repository should not error")
+		if len(result.Content) > 0 {
+			text := ""
+			if textContent, ok := mcp.AsTextContent(result.Content[0]); ok {
+				text = textContent.Text
+			}
+			assert.Contains(t, text, repo2Dir, "Output should reference the second repository")
+		}
+
+		// Invalid repository (should error)
+		request = mcp.CallToolRequest{}
+		request.Params.Name = "git_status"
+		request.Params.Arguments = map[string]interface{}{
+			"repo_path": "/invalid/path",
+		}
+
+		result, err = server.gitStatusHandler(context.Background(), request)
+		require.NoError(t, err, "Handler should not return error, but result should indicate error")
+		if len(result.Content) > 0 {
+			text := ""
+			if textContent, ok := mcp.AsTextContent(result.Content[0]); ok {
+				text = textContent.Text
+			}
+			assert.True(t, strings.Contains(text, "Repository path error") || 
+			           strings.Contains(text, "access denied"),
+			           "Output should indicate repository path error")
+		}
+	})
+}

--- a/pkg/server.go
+++ b/pkg/server.go
@@ -3,6 +3,7 @@ package pkg
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -14,24 +15,102 @@ import (
 // GitServer represents the Git MCP server
 type GitServer struct {
 	server      *server.MCPServer
-	repoPath    string
+	repoPaths   []string // Changed from single string to array of strings
 	gitOps      gitops.GitOperations
 	writeAccess bool
 }
 
 // NewGitServer creates a new Git MCP server
-func NewGitServer(repoPath string, gitOps gitops.GitOperations, writeAccess bool) *GitServer {
+func NewGitServer(repoPaths []string, gitOps gitops.GitOperations, writeAccess bool) *GitServer {
 	s := server.NewMCPServer(
 		"Git MCP Server",
 		"1.0.0",
 	)
 
+	// Normalize repository paths
+	normalizedPaths := make([]string, 0, len(repoPaths))
+	for _, path := range repoPaths {
+		if path == "" {
+			continue
+		}
+		
+		absPath, err := filepath.Abs(path)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to resolve path %s: %v\n", path, err)
+			continue
+		}
+		
+		// Check if it's a git repository
+		gitDirPath := filepath.Join(absPath, ".git")
+		if info, err := os.Stat(gitDirPath); err == nil && info.IsDir() {
+			normalizedPaths = append(normalizedPaths, absPath)
+		} else {
+			fmt.Fprintf(os.Stderr, "Warning: not a git repository: %s\n", absPath)
+		}
+	}
+
 	return &GitServer{
 		server:      s,
-		repoPath:    repoPath,
+		repoPaths:   normalizedPaths,
 		gitOps:      gitOps,
 		writeAccess: writeAccess,
 	}
+}
+
+// isPathInAllowedRepos checks if a path is within any of the allowed repositories
+func (s *GitServer) isPathInAllowedRepos(path string) bool {
+	// Ensure path is absolute and clean
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return false
+	}
+
+	// Check if the path is within any of the allowed repositories
+	for _, repoPath := range s.repoPaths {
+		if strings.HasPrefix(absPath, repoPath) {
+			return true
+		}
+	}
+	return false
+}
+
+// validateRepoPath validates and normalizes a repository path
+func (s *GitServer) validateRepoPath(requestedPath string) (string, error) {
+	// If no specific path is provided, but we have repositories configured
+	if requestedPath == "" {
+		if len(s.repoPaths) > 0 {
+			// Use the first repository as default
+			return s.repoPaths[0], nil
+		}
+		return "", fmt.Errorf("no repository specified and no defaults configured")
+	}
+
+	// Always convert to absolute path first
+	absPath, err := filepath.Abs(requestedPath)
+	if err != nil {
+		return "", fmt.Errorf("invalid path: %w", err)
+	}
+
+	// Check if path is within allowed repositories
+	if !s.isPathInAllowedRepos(absPath) {
+		return "", fmt.Errorf(
+			"access denied - path outside allowed repositories: %s",
+			absPath,
+		)
+	}
+
+	// Ensure it's a valid git repository
+	gitDirPath := filepath.Join(absPath, ".git")
+	if _, err := os.Stat(gitDirPath); os.IsNotExist(err) {
+		return "", fmt.Errorf("not a git repository: %s", absPath)
+	}
+
+	return absPath, nil
+}
+
+// getRepoPathForOperation determines which repo path to use for an operation
+func (s *GitServer) getRepoPathForOperation(requestedPath string) (string, error) {
+	return s.validateRepoPath(requestedPath)
 }
 
 func GetReadOnlyToolNames() map[string]bool {
@@ -48,7 +127,7 @@ func GetReadOnlyToolNames() map[string]bool {
 func GetLocalOnlyToolNames() map[string]bool {
 	// local tools that alter state, complementing the read-only tools
 	result := map[string]bool{
-		"git_init": true,
+		"git_init":          true,
 		"git_create_branch": true,
 		"git_checkout":      true,
 		"git_commit":        true,
@@ -62,13 +141,12 @@ func GetLocalOnlyToolNames() map[string]bool {
 	return result
 }
 
-
 // RegisterTools registers all Git tools with the MCP server
 func (s *GitServer) RegisterTools() {
 	// Register git_status tool
 	var repoPathDesc string
 
-	if s.repoPath == "" {
+	if len(s.repoPaths) == 0 {
 		repoPathDesc = "Path to Git repository"
 		s.server.AddTool(mcp.NewTool("git_status",
 			mcp.WithDescription("Shows the working tree status"),
@@ -78,7 +156,12 @@ func (s *GitServer) RegisterTools() {
 			),
 		), s.gitStatusHandler)
 	} else {
-		repoPathDesc = fmt.Sprintf("Path to Git repository (default: %s)", s.repoPath)
+		defaultRepo := s.repoPaths[0]
+		if len(s.repoPaths) == 1 {
+			repoPathDesc = fmt.Sprintf("Path to Git repository (default: %s)", defaultRepo)
+		} else {
+			repoPathDesc = fmt.Sprintf("Path to Git repository (default: %s, %d repositories available)", defaultRepo, len(s.repoPaths))
+		}
 		s.server.AddTool(mcp.NewTool("git_status",
 			mcp.WithDescription("Shows the working tree status"),
 			mcp.WithString("repo_path",
@@ -88,7 +171,7 @@ func (s *GitServer) RegisterTools() {
 	}
 
 	// Register git_diff_unstaged tool
-	if s.repoPath == "" {
+	if len(s.repoPaths) == 0 {
 		s.server.AddTool(mcp.NewTool("git_diff_unstaged",
 			mcp.WithDescription("Shows changes in the working directory that are not yet staged"),
 			mcp.WithString("repo_path",
@@ -106,7 +189,7 @@ func (s *GitServer) RegisterTools() {
 	}
 
 	// Register git_diff_staged tool
-	if s.repoPath == "" {
+	if len(s.repoPaths) == 0 {
 		s.server.AddTool(mcp.NewTool("git_diff_staged",
 			mcp.WithDescription("Shows changes that are staged for commit"),
 			mcp.WithString("repo_path",
@@ -244,6 +327,11 @@ func (s *GitServer) RegisterTools() {
 	)
 	s.server.AddTool(initTool, s.gitInitHandler)
 
+	// Register git_list_repositories tool
+	s.server.AddTool(mcp.NewTool("git_list_repositories",
+		mcp.WithDescription("Lists all available Git repositories"),
+	), s.gitListRepositoriesHandler)
+
 	if s.writeAccess {
 		// Register git_push tool
 		pushTool := mcp.NewTool("git_push",
@@ -271,14 +359,11 @@ func (s *GitServer) Serve() error {
 // Tool handlers
 
 func (s *GitServer) gitStatusHandler(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	repoPath, ok := request.Params.Arguments["repo_path"].(string)
-	if !ok {
-		// If repo_path is not provided but we have a default, use it
-		if s.repoPath != "" {
-			repoPath = s.repoPath
-		} else {
-			return mcp.NewToolResultError("repo_path must be a string"), nil
-		}
+	requestedPath, _ := request.Params.Arguments["repo_path"].(string)
+	
+	repoPath, err := s.getRepoPathForOperation(requestedPath)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("Repository path error: %v", err)), nil
 	}
 
 	status, err := s.gitOps.GetStatus(repoPath)
@@ -286,18 +371,15 @@ func (s *GitServer) gitStatusHandler(ctx context.Context, request mcp.CallToolRe
 		return mcp.NewToolResultError(fmt.Sprintf("Failed to get status: %v", err)), nil
 	}
 
-	return mcp.NewToolResultText(fmt.Sprintf("Repository status:\n%s", status)), nil
+	return mcp.NewToolResultText(fmt.Sprintf("Repository status for %s:\n%s", repoPath, status)), nil
 }
 
 func (s *GitServer) gitDiffUnstagedHandler(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	repoPath, ok := request.Params.Arguments["repo_path"].(string)
-	if !ok {
-		// If repo_path is not provided but we have a default, use it
-		if s.repoPath != "" {
-			repoPath = s.repoPath
-		} else {
-			return mcp.NewToolResultError("repo_path must be a string"), nil
-		}
+	requestedPath, _ := request.Params.Arguments["repo_path"].(string)
+	
+	repoPath, err := s.getRepoPathForOperation(requestedPath)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("Repository path error: %v", err)), nil
 	}
 
 	diff, err := s.gitOps.GetDiffUnstaged(repoPath)
@@ -305,18 +387,15 @@ func (s *GitServer) gitDiffUnstagedHandler(ctx context.Context, request mcp.Call
 		return mcp.NewToolResultError(fmt.Sprintf("Failed to get unstaged diff: %v", err)), nil
 	}
 
-	return mcp.NewToolResultText(fmt.Sprintf("Unstaged changes:\n%s", diff)), nil
+	return mcp.NewToolResultText(fmt.Sprintf("Unstaged changes for %s:\n%s", repoPath, diff)), nil
 }
 
 func (s *GitServer) gitDiffStagedHandler(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	repoPath, ok := request.Params.Arguments["repo_path"].(string)
-	if !ok {
-		// If repo_path is not provided but we have a default, use it
-		if s.repoPath != "" {
-			repoPath = s.repoPath
-		} else {
-			return mcp.NewToolResultError("repo_path must be a string"), nil
-		}
+	requestedPath, _ := request.Params.Arguments["repo_path"].(string)
+	
+	repoPath, err := s.getRepoPathForOperation(requestedPath)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("Repository path error: %v", err)), nil
 	}
 
 	diff, err := s.gitOps.GetDiffStaged(repoPath)
@@ -324,18 +403,15 @@ func (s *GitServer) gitDiffStagedHandler(ctx context.Context, request mcp.CallTo
 		return mcp.NewToolResultError(fmt.Sprintf("Failed to get staged diff: %v", err)), nil
 	}
 
-	return mcp.NewToolResultText(fmt.Sprintf("Staged changes:\n%s", diff)), nil
+	return mcp.NewToolResultText(fmt.Sprintf("Staged changes for %s:\n%s", repoPath, diff)), nil
 }
 
 func (s *GitServer) gitDiffHandler(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	repoPath, ok := request.Params.Arguments["repo_path"].(string)
-	if !ok {
-		// If repo_path is not provided but we have a default, use it
-		if s.repoPath != "" {
-			repoPath = s.repoPath
-		} else {
-			return mcp.NewToolResultError("repo_path must be a string"), nil
-		}
+	requestedPath, _ := request.Params.Arguments["repo_path"].(string)
+	
+	repoPath, err := s.getRepoPathForOperation(requestedPath)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("Repository path error: %v", err)), nil
 	}
 
 	target, ok := request.Params.Arguments["target"].(string)
@@ -348,18 +424,15 @@ func (s *GitServer) gitDiffHandler(ctx context.Context, request mcp.CallToolRequ
 		return mcp.NewToolResultError(fmt.Sprintf("Failed to get diff: %v", err)), nil
 	}
 
-	return mcp.NewToolResultText(fmt.Sprintf("Diff with %s:\n%s", target, diff)), nil
+	return mcp.NewToolResultText(fmt.Sprintf("Diff with %s for %s:\n%s", target, repoPath, diff)), nil
 }
 
 func (s *GitServer) gitCommitHandler(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	repoPath, ok := request.Params.Arguments["repo_path"].(string)
-	if !ok {
-		// If repo_path is not provided but we have a default, use it
-		if s.repoPath != "" {
-			repoPath = s.repoPath
-		} else {
-			return mcp.NewToolResultError("repo_path must be a string"), nil
-		}
+	requestedPath, _ := request.Params.Arguments["repo_path"].(string)
+	
+	repoPath, err := s.getRepoPathForOperation(requestedPath)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("Repository path error: %v", err)), nil
 	}
 
 	message, ok := request.Params.Arguments["message"].(string)
@@ -376,14 +449,11 @@ func (s *GitServer) gitCommitHandler(ctx context.Context, request mcp.CallToolRe
 }
 
 func (s *GitServer) gitAddHandler(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	repoPath, ok := request.Params.Arguments["repo_path"].(string)
-	if !ok {
-		// If repo_path is not provided but we have a default, use it
-		if s.repoPath != "" {
-			repoPath = s.repoPath
-		} else {
-			return mcp.NewToolResultError("repo_path must be a string"), nil
-		}
+	requestedPath, _ := request.Params.Arguments["repo_path"].(string)
+	
+	repoPath, err := s.getRepoPathForOperation(requestedPath)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("Repository path error: %v", err)), nil
 	}
 
 	filesStr, ok := request.Params.Arguments["files"].(string)
@@ -407,14 +477,11 @@ func (s *GitServer) gitAddHandler(ctx context.Context, request mcp.CallToolReque
 }
 
 func (s *GitServer) gitResetHandler(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	repoPath, ok := request.Params.Arguments["repo_path"].(string)
-	if !ok {
-		// If repo_path is not provided but we have a default, use it
-		if s.repoPath != "" {
-			repoPath = s.repoPath
-		} else {
-			return mcp.NewToolResultError("repo_path must be a string"), nil
-		}
+	requestedPath, _ := request.Params.Arguments["repo_path"].(string)
+	
+	repoPath, err := s.getRepoPathForOperation(requestedPath)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("Repository path error: %v", err)), nil
 	}
 
 	result, err := s.gitOps.ResetStaged(repoPath)
@@ -426,14 +493,11 @@ func (s *GitServer) gitResetHandler(ctx context.Context, request mcp.CallToolReq
 }
 
 func (s *GitServer) gitLogHandler(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	repoPath, ok := request.Params.Arguments["repo_path"].(string)
-	if !ok {
-		// If repo_path is not provided but we have a default, use it
-		if s.repoPath != "" {
-			repoPath = s.repoPath
-		} else {
-			return mcp.NewToolResultError("repo_path must be a string"), nil
-		}
+	requestedPath, _ := request.Params.Arguments["repo_path"].(string)
+	
+	repoPath, err := s.getRepoPathForOperation(requestedPath)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("Repository path error: %v", err)), nil
 	}
 
 	maxCount := 10
@@ -448,18 +512,15 @@ func (s *GitServer) gitLogHandler(ctx context.Context, request mcp.CallToolReque
 		return mcp.NewToolResultError(fmt.Sprintf("Failed to get log: %v", err)), nil
 	}
 
-	return mcp.NewToolResultText(fmt.Sprintf("Commit history:\n%s", strings.Join(logs, "\n"))), nil
+	return mcp.NewToolResultText(fmt.Sprintf("Commit history for %s:\n%s", repoPath, strings.Join(logs, "\n"))), nil
 }
 
 func (s *GitServer) gitCreateBranchHandler(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	repoPath, ok := request.Params.Arguments["repo_path"].(string)
-	if !ok {
-		// If repo_path is not provided but we have a default, use it
-		if s.repoPath != "" {
-			repoPath = s.repoPath
-		} else {
-			return mcp.NewToolResultError("repo_path must be a string"), nil
-		}
+	requestedPath, _ := request.Params.Arguments["repo_path"].(string)
+	
+	repoPath, err := s.getRepoPathForOperation(requestedPath)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("Repository path error: %v", err)), nil
 	}
 
 	branchName, ok := request.Params.Arguments["branch_name"].(string)
@@ -483,14 +544,11 @@ func (s *GitServer) gitCreateBranchHandler(ctx context.Context, request mcp.Call
 }
 
 func (s *GitServer) gitCheckoutHandler(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	repoPath, ok := request.Params.Arguments["repo_path"].(string)
-	if !ok {
-		// If repo_path is not provided but we have a default, use it
-		if s.repoPath != "" {
-			repoPath = s.repoPath
-		} else {
-			return mcp.NewToolResultError("repo_path must be a string"), nil
-		}
+	requestedPath, _ := request.Params.Arguments["repo_path"].(string)
+	
+	repoPath, err := s.getRepoPathForOperation(requestedPath)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("Repository path error: %v", err)), nil
 	}
 
 	branchName, ok := request.Params.Arguments["branch_name"].(string)
@@ -507,14 +565,11 @@ func (s *GitServer) gitCheckoutHandler(ctx context.Context, request mcp.CallTool
 }
 
 func (s *GitServer) gitShowHandler(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	repoPath, ok := request.Params.Arguments["repo_path"].(string)
-	if !ok {
-		// If repo_path is not provided but we have a default, use it
-		if s.repoPath != "" {
-			repoPath = s.repoPath
-		} else {
-			return mcp.NewToolResultError("repo_path must be a string"), nil
-		}
+	requestedPath, _ := request.Params.Arguments["repo_path"].(string)
+	
+	repoPath, err := s.getRepoPathForOperation(requestedPath)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("Repository path error: %v", err)), nil
 	}
 
 	revision, ok := request.Params.Arguments["revision"].(string)
@@ -531,29 +586,26 @@ func (s *GitServer) gitShowHandler(ctx context.Context, request mcp.CallToolRequ
 }
 
 func (s *GitServer) gitInitHandler(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	repoPath, ok := request.Params.Arguments["repo_path"].(string)
-	if !ok {
-		// If repo_path is not provided but we have a default, use it
-		if s.repoPath != "" {
-			repoPath = s.repoPath
-		} else {
-			return mcp.NewToolResultError("repo_path must be a string"), nil
-		}
+	requestedPath, _ := request.Params.Arguments["repo_path"].(string)
+	
+	// For init, we don't validate through getRepoPathForOperation since we're creating a new repo
+	if requestedPath == "" {
+		return mcp.NewToolResultError("repo_path must be specified for initialization"), nil
 	}
 
 	// Ensure the path is absolute
-	if !filepath.IsAbs(repoPath) {
-		absPath, err := filepath.Abs(repoPath)
-		if err != nil {
-			return mcp.NewToolResultError(fmt.Sprintf("Failed to get absolute path: %v", err)), nil
-		}
-		repoPath = absPath
+	absPath, err := filepath.Abs(requestedPath)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("Failed to get absolute path: %v", err)), nil
 	}
 
-	result, err := s.gitOps.InitRepo(repoPath)
+	result, err := s.gitOps.InitRepo(absPath)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("Failed to initialize repository: %v", err)), nil
 	}
+
+	// Add the new repository to our list of managed repositories
+	s.repoPaths = append(s.repoPaths, absPath)
 
 	return mcp.NewToolResultText(result), nil
 }
@@ -564,14 +616,11 @@ func (s *GitServer) gitPushHandler(ctx context.Context, request mcp.CallToolRequ
 		return mcp.NewToolResultError("Write access is disabled. Use --write-access flag to enable remote operations."), nil
 	}
 
-	repoPath, ok := request.Params.Arguments["repo_path"].(string)
-	if !ok {
-		// If repo_path is not provided but we have a default, use it
-		if s.repoPath != "" {
-			repoPath = s.repoPath
-		} else {
-			return mcp.NewToolResultError("repo_path must be a string"), nil
-		}
+	requestedPath, _ := request.Params.Arguments["repo_path"].(string)
+	
+	repoPath, err := s.getRepoPathForOperation(requestedPath)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("Repository path error: %v", err)), nil
 	}
 
 	remote := ""
@@ -594,4 +643,22 @@ func (s *GitServer) gitPushHandler(ctx context.Context, request mcp.CallToolRequ
 	}
 
 	return mcp.NewToolResultText(result), nil
+}
+
+// gitListRepositoriesHandler lists all available repositories
+func (s *GitServer) gitListRepositoriesHandler(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	if len(s.repoPaths) == 0 {
+		return mcp.NewToolResultText("No repositories configured"), nil
+	}
+	
+	var result strings.Builder
+	result.WriteString(fmt.Sprintf("Available repositories (%d):\n\n", len(s.repoPaths)))
+	
+	for i, repoPath := range s.repoPaths {
+		// Get the repository name (last part of the path)
+		repoName := filepath.Base(repoPath)
+		result.WriteString(fmt.Sprintf("%d. %s (%s)\n", i+1, repoName, repoPath))
+	}
+	
+	return mcp.NewToolResultText(result.String()), nil
 }

--- a/pkg/server_test.go
+++ b/pkg/server_test.go
@@ -210,7 +210,7 @@ func TestGitOperations(t *testing.T) {
 				}
 
 				// Create server with local repository
-				server := NewGitServer(localDir, gitOps, true) // Enable write access for tests
+				server := NewGitServer([]string{localDir}, gitOps, true) // Enable write access for tests
 				server.RegisterTools()
 
 				// Execute the action and validate results


### PR DESCRIPTION
This PR adds multi-repository support, allowing the Git MCP Server to monitor and operate on multiple repositories simultaneously. Users can now specify multiple repositories in several flexible ways, and a new tool has been added to list all available repositories.

Resolves #2 

## Key Features

1. **Multiple Repository Specification**:
   - Via comma-separated paths: `-r=/path/to/repo1,/path/to/repo2`
   - Via multiple flag instances: `-r=/path/to/repo1 -r=/path/to/repo2`
   - Via positional arguments: `serve /path/to/repo1 /path/to/repo2`

2. **Intelligent Repository Selection**:
   - When a specific repository is requested for an operation, it's used
   - When no repository is specified, the first repository is used as default
   - Each command output indicates which repository was used

3. **New Tool: `git_list_repositories`**:
   - Lists all available repositories the server is monitoring
   - Shows repository path and name
   - Helps users keep track of configured repositories

4. **Backward Compatibility**:
   - All existing commands and workflows continue to work
   - Single repository mode still supported (just specify one repository)

## Implementation Details

1. Changed `GitServer` to store an array of repository paths instead of a single path
2. Added repository validation logic to check if paths are valid git repositories
3. Changed `-r/--repository` from `StringVar` to `StringSliceVar` to support multiple values
4. Modified all handler functions to use repository selection logic
5. Updated documentation to explain the new features and usage patterns
6. Added specific tests for multi-repository functionality

## Testing

Automated tests have been added to verify:
- The new `git_list_repositories` tool functions correctly
- Repository selection logic works as expected
- Operations across multiple repositories are handled properly
- Invalid repository paths are properly rejected

### Test with Claude Desktop

I also tested with Claude Desktop 0.8.1 / Sonnet 3.7 with this config in `claude_desktop_config.json`:

```json
    "git": {
      "command": "~/dev/forks/git-mcp-go/git-mcp-go",
      "args": ["serve", "~/dev/forks/git-mcp-go", "~/dev/forks/wireguard-go"]
    },
```

And here is the conversation:

```markdown
please use the git mcp tool available to you to see which repos you have access to

---

I'll help you explore the Git repositories that are available through the tools. Let's list the repositories first.

I have access to two Git repositories:

1. `git-mcp-go` at the path `~/dev/forks/git-mcp-go`
2. `wireguard-go` at the path `~/dev/forks/wireguard-go`

Would you like me to examine either of these repositories in more detail? I can check their status, commit history, or look at specific files within them.

---

Please show me a summary of the last commit for each repo.

---

I'll show you the summary of the last commit for each repository. Let's check them one by one.

First, let's look at the last commit for the git-mcp-go repository:

Now, let's check the last commit for the wireguard-go repository:

Here's a summary of the last commit for each repository:

1. **git-mcp-go**:
   - Commit: 553d6fc9ce2640699ac57ffe84b1709fb1b6aef6
   - Author: tomholford
   - Date: Sun Mar 16, 2025 (today)
   - Message: "Simplify repository flag handling"

2. **wireguard-go**:
   - Commit: 49e120adda6ee503dd14cf2799e34f73809a8c05
   - Author: tomholford
   - Date: Mon Jul 22, 2024
   - Message: "global: linter and deprecated"

The git-mcp-go repository has a very recent commit from today, while the wireguard-go repository's last commit is from July 2024.

```

## Usage Examples

```bash
# Run with multiple repositories using comma-separated values
./git-mcp-go serve -r=/path/to/repo1,/path/to/repo2,/path/to/repo3

# Run with multiple repository flags
./git-mcp-go serve -r=/path/to/repo1 -r=/path/to/repo2

# Run with repositories as arguments
./git-mcp-go serve /path/to/repo1 /path/to/repo2 /path/to/repo3

# List all available repositories
# (Output will show all monitored repositories)
```

This feature significantly improves the user experience when working with multiple repositories, making the Git MCP Server more versatile and efficient.