### PR TITLE
Add patch application tools and improve git_add parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ This MCP server provides the following Git operations as tools:
 - **git_init**: Initialize a new Git repository
 - **git_push**: Pushes local commits to a remote repository (requires `--write-access` flag)
 - **git_list_repositories**: Lists all available Git repositories
+- **git_apply_patch_string**: Applies a patch from a string to a git repository
+- **git_apply_patch_file**: Applies a patch from a file to a git repository
 
 ## Installation
 

--- a/pkg/gitops/interface.go
+++ b/pkg/gitops/interface.go
@@ -15,4 +15,6 @@ type GitOperations interface {
 	InitRepo(repoPath string) (string, error)
 	ShowCommit(repoPath string, revision string) (string, error)
 	PushChanges(repoPath string, remote string, branch string) (string, error)
+	ApplyPatchFromString(repoPath string, patchString string) (string, error)
+	ApplyPatchFromFile(repoPath string, patchFilePath string) (string, error)
 }

--- a/pkg/server.go
+++ b/pkg/server.go
@@ -491,11 +491,21 @@ func (s *GitServer) gitAddHandler(ctx context.Context, request mcp.CallToolReque
 		return mcp.NewToolResultError("files must be a string"), nil
 	}
 
-	// Split the comma-separated list of files
-	files := strings.Split(filesStr, ",")
-	// Trim spaces from each file path
-	for i, file := range files {
-		files[i] = strings.TrimSpace(file)
+	// LLMs are inconsistent with how they interact with this
+	// So, support either single file, comma-separated, or space-delimited
+	var files []string
+	if strings.Contains(filesStr, ",") {
+		files := strings.Split(filesStr, ",")
+		for i, file := range files {
+			files[i] = strings.TrimSpace(file)
+		}
+	} else if strings.Contains(filesStr, " ") {
+		files := strings.Split(filesStr, " ")
+		for i, file := range files {
+			files[i] = strings.TrimSpace(file)
+		}
+	} else {
+		files = []string{filesStr}
 	}
 
 	result, err := s.gitOps.AddFiles(repoPath, files)


### PR DESCRIPTION
Adds two missing git operations and fixes LLM interaction issues with file staging.

### git_apply_patch_string / git_apply_patch_file
- Apply patches from string content or file paths
- Implements missing `git apply` functionality in MCP interface
- Added to both shell and gogit backends

### Enhanced git_add parsing
- Supports comma-separated: `"file1.js,file2.js"`
- Supports space-delimited: `"file1.js file2.js"`  
- Supports single file: `"file1.js"`
- Fixes LLM inconsistency when staging multiple files